### PR TITLE
Add chatgpt support

### DIFF
--- a/src/collective/translators/chatgpt/configure.zcml
+++ b/src/collective/translators/chatgpt/configure.zcml
@@ -1,0 +1,27 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    i18n_domain="collective.translators"
+    >
+
+  <utility
+      provides="plone.app.multilingual.interfaces.IExternalTranslationService"
+      name="chatgpt_translate"
+      component=".utility.ChatGPT"
+      />
+
+  <browser:page
+      name="chatgpt-translator-controlpanel"
+      for="plone.base.interfaces.IPloneSiteRoot"
+      class=".controlpanel.ChatGPTControlPanel"
+      permission="cmf.ManagePortal"
+      layer="..interfaces.IBrowserLayer"
+      />
+
+  <adapter
+      factory=".controlpanel.ChatGPTRegistryConfigletPanel"
+      name="chatgpt-controlpanel"
+      />
+
+</configure>

--- a/src/collective/translators/chatgpt/controlpanel.py
+++ b/src/collective/translators/chatgpt/controlpanel.py
@@ -1,0 +1,72 @@
+from collective.translators import _
+from collective.translators.interfaces import IControlPanel
+from plone.app.registry.browser import controlpanel
+from plone.restapi.controlpanels import RegistryConfigletPanel
+from zope import schema
+from zope.component import adapter
+from zope.interface import Interface
+
+
+class IChatGPTControlPanel(IControlPanel):
+    """Control panel interface for ChatGPT translation service."""
+
+    api_key = schema.TextLine(
+        title=_("API Key"),
+        description=_("The API key for the ChatGPT service."),
+        required=False,
+    )
+
+    base_url = schema.TextLine(
+        title=_("API Base URL"),
+        description=_(
+            "The base URL for the ChatGPT API (e.g., https://api.openai.com/v1). Leave empty to use default."
+        ),
+        required=False,
+    )
+
+    model = schema.TextLine(
+        title=_("Model"),
+        description=_(
+            "The ChatGPT model to use (e.g., gpt-4o, gpt-4-turbo, gpt-3.5-turbo)."
+        ),
+        default="gpt-3.5-turbo",
+        required=False,
+    )
+
+    temperature = schema.Float(
+        title=_("Temperature"),
+        description=_(
+            "Controls randomness: 0 for deterministic, higher values for more random. Value between 0 and 2."
+        ),
+        default=0.3,
+        min=0.0,
+        max=2.0,
+        required=False,
+    )
+
+    max_tokens = schema.Int(
+        title=_("Max Tokens"),
+        description=_(
+            "Maximum number of tokens to generate in the translation response."
+        ),
+        default=1000,
+        required=False,
+    )
+
+
+class ChatGPTControlPanel(controlpanel.RegistryEditForm):
+    id = "ChatGPTControlPanel"
+    label = _("ChatGPT Translation Service")
+    schema = IChatGPTControlPanel
+
+
+@adapter(Interface, Interface)
+class ChatGPTRegistryConfigletPanel(RegistryConfigletPanel):
+    """ChatGPT control panel adapter."""
+
+    schema = IChatGPTControlPanel
+    schema_prefix = "chatgpt"
+    configlet_id = "chatgpt-controlpanel"
+    configlet_category_id = "Products"
+    title = _("ChatGPT Settings")
+    group = "Products"

--- a/src/collective/translators/chatgpt/utility.py
+++ b/src/collective/translators/chatgpt/utility.py
@@ -1,0 +1,99 @@
+from .controlpanel import IChatGPTControlPanel
+from openai import OpenAI
+from plone import api
+
+
+class ChatGPTFactory:
+    """Factory for ChatGPT translation service."""
+
+    @property
+    def order(self):
+        return api.portal.get_registry_record(
+            name="order", interface=IChatGPTControlPanel
+        )
+
+    @property
+    def translator(self):
+        """Get the OpenAI client with configured settings."""
+        api_key = api.portal.get_registry_record(
+            name="api_key", interface=IChatGPTControlPanel
+        )
+        base_url = api.portal.get_registry_record(
+            name="base_url", interface=IChatGPTControlPanel
+        )
+
+        # If base_url is provided, use it; otherwise use OpenAI's default
+        if base_url:
+            return OpenAI(api_key=api_key, base_url=base_url)
+        return OpenAI(api_key=api_key)
+
+    def is_available(self):
+        """Check if the service is enabled."""
+        value = api.portal.get_registry_record(
+            name="enabled", interface=IChatGPTControlPanel
+        )
+        return value
+
+    def available_languages(self):
+        """ChatGPT supports a wide range of languages.
+
+        Return empty list as ChatGPT can translate between any language pair.
+        """
+        return []
+
+    def translate_content(self, content, source_language, target_language):
+        """Translate content using ChatGPT API.
+
+        Args:
+            content: Text to translate
+            source_language: Source language code
+            target_language: Target language code
+
+        Returns:
+            Translated text or None if translation fails
+        """
+        try:
+            client = self.translator
+
+            # Get model from settings
+            model = api.portal.get_registry_record(
+                name="model", interface=IChatGPTControlPanel
+            )
+
+            # Get temperature from settings
+            temperature = api.portal.get_registry_record(
+                name="temperature", interface=IChatGPTControlPanel
+            )
+
+            # Get max_tokens from settings
+            max_tokens = api.portal.get_registry_record(
+                name="max_tokens", interface=IChatGPTControlPanel
+            )
+
+            response = client.chat.completions.create(
+                model=model,
+                messages=[
+                    {
+                        "role": "system",
+                        "content": "You are a professional translator. Translate the user's text accurately and only return the translated content without additional explanations.",
+                    },
+                    {
+                        "role": "user",
+                        "content": f"Translate the following text from {source_language} to {target_language}: {content}",
+                    },
+                ],
+                max_tokens=max_tokens,
+                temperature=temperature,
+            )
+            translated_text = response.choices[0].message.content
+            return translated_text
+        except Exception as e:
+            api.portal.show_message(
+                message=f"Translation error: {str(e)}",
+                request=api.portal.get().REQUEST,
+                type="error",
+            )
+            return None
+
+
+ChatGPT = ChatGPTFactory()

--- a/src/collective/translators/configure.zcml
+++ b/src/collective/translators/configure.zcml
@@ -33,6 +33,10 @@
       zcml:condition="installed openai"
       />
   <include
+      package=".chatgpt"
+      zcml:condition="installed openai"
+      />
+  <include
       package=".ollama"
       zcml:condition="installed ollama"
       />

--- a/src/collective/translators/libretranslate/utility.py
+++ b/src/collective/translators/libretranslate/utility.py
@@ -62,9 +62,9 @@ class LibreTranslateTranslatorFactory:
                 "api_key": self.api_key,
             },
             timeout=self.timeout,
-        ).json()
-        if res.ok:
-            return res["translatedText"]
+        )
+        if res.status_code == 200:
+            return res.json().get("translatedText", "")
 
         return ""
 

--- a/src/collective/translators/locales/collective.translators.pot
+++ b/src/collective/translators/locales/collective.translators.pot
@@ -17,6 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.translators\n"
 
+#: ../chatgpt/controlpanel.py:11
 #: ../deepl/controlpanel.py:13
 #: ../deepseek/controlpanel.py:12
 #: ../google/controlpanel.py:12
@@ -41,12 +42,29 @@ msgstr ""
 msgid "Auto detect the source language?"
 msgstr ""
 
+#: ../chatgpt/controlpanel.py:26
+msgid "API Base URL"
+msgstr ""
+
 #: ../profiles.zcml:13
 msgid "Collective Translators: Install"
 msgstr ""
 
 #: ../profiles.zcml:21
 msgid "Collective Translators: Uninstall"
+msgstr ""
+
+#: ../chatgpt/controlpanel.py:48
+msgid "ChatGPT Settings"
+msgstr ""
+
+#: ../chatgpt/controlpanel.py:36
+msgid "ChatGPT Translation Service"
+msgstr ""
+
+#: ../deepseek/controlpanel.py:48
+#: ../profiles/default/controlpanel.xml
+msgid "ChatGPT Settings"
 msgstr ""
 
 #: ../deepseek/controlpanel.py:32
@@ -149,6 +167,18 @@ msgstr ""
 msgid "Target languages"
 msgstr ""
 
+#: ../chatgpt/controlpanel.py:11
+msgid "The API key for the ChatGPT service."
+msgstr ""
+
+#: ../chatgpt/controlpanel.py:26
+msgid "The base URL for the ChatGPT API (e.g., https://api.openai.com/v1). Leave empty to use default."
+msgstr ""
+
+#: ../chatgpt/controlpanel.py:32
+msgid "The ChatGPT model to use (e.g., gpt-4o, gpt-4-turbo, gpt-3.5-turbo)."
+msgstr ""
+
 #: ../deepseek/controlpanel.py:13
 msgid "The API key for the DeepSeek service."
 msgstr ""
@@ -175,6 +205,26 @@ msgstr ""
 
 #: ../aws/controlpanel.py:18
 msgid "The secret key for the access to AWS Translate service."
+msgstr ""
+
+#: ../chatgpt/controlpanel.py:38
+msgid "Model"
+msgstr ""
+
+#: ../chatgpt/controlpanel.py:44
+msgid "Temperature"
+msgstr ""
+
+#: ../chatgpt/controlpanel.py:44
+msgid "Controls randomness: 0 for deterministic, higher values for more random. Value between 0 and 2."
+msgstr ""
+
+#: ../chatgpt/controlpanel.py:52
+msgid "Max Tokens"
+msgstr ""
+
+#: ../chatgpt/controlpanel.py:52
+msgid "Maximum number of tokens to generate in the translation response."
 msgstr ""
 
 #: ../libretranslate/controlpanel.py:19

--- a/src/collective/translators/locales/it/LC_MESSAGES/collective.translators.po
+++ b/src/collective/translators/locales/it/LC_MESSAGES/collective.translators.po
@@ -17,6 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
+#: ../chatgpt/controlpanel.py:11
 #: ../deepl/controlpanel.py:13
 #: ../deepseek/controlpanel.py:12
 #: ../google/controlpanel.py:12
@@ -41,6 +42,10 @@ msgstr "Chiave di accesso"
 msgid "Auto detect the source language?"
 msgstr ""
 
+#: ../chatgpt/controlpanel.py:26
+msgid "API Base URL"
+msgstr "URL Base API"
+
 #: ../profiles.zcml:13
 msgid "Collective Translators: Install"
 msgstr ""
@@ -48,6 +53,19 @@ msgstr ""
 #: ../profiles.zcml:21
 msgid "Collective Translators: Uninstall"
 msgstr ""
+
+#: ../chatgpt/controlpanel.py:48
+msgid "ChatGPT Settings"
+msgstr "Impostazioni ChatGPT"
+
+#: ../chatgpt/controlpanel.py:36
+msgid "ChatGPT Translation Service"
+msgstr "Servizio di traduzione ChatGPT"
+
+#: ../deepseek/controlpanel.py:48
+#: ../profiles/default/controlpanel.xml
+msgid "ChatGPT Settings"
+msgstr "Impostazioni ChatGPT"
 
 #: ../deepseek/controlpanel.py:32
 #: ../profiles/default/controlpanel.xml
@@ -137,6 +155,18 @@ msgstr "Chiave segreta"
 msgid "Select which source languages does this service allow"
 msgstr ""
 
+#: ../chatgpt/controlpanel.py:11
+msgid "The API key for the ChatGPT service."
+msgstr "La chiave API per il servizio ChatGPT."
+
+#: ../chatgpt/controlpanel.py:26
+msgid "The base URL for the ChatGPT API (e.g., https://api.openai.com/v1). Leave empty to use default."
+msgstr "L'URL di base per l'API ChatGPT (ad es. https://api.openai.com/v1). Lascia vuoto per usare il valore predefinito."
+
+#: ../chatgpt/controlpanel.py:32
+msgid "The ChatGPT model to use (e.g., gpt-4o, gpt-4-turbo, gpt-3.5-turbo)."
+msgstr "Il modello ChatGPT da utilizzare (ad es. gpt-4o, gpt-4-turbo, gpt-3.5-turbo)."
+
 #: ../interfaces.py:42
 msgid "Select which target languages does this service allow"
 msgstr ""
@@ -176,6 +206,26 @@ msgstr "La regione per il servizio AWS Translate."
 #: ../aws/controlpanel.py:18
 msgid "The secret key for the access to AWS Translate service."
 msgstr "La chiave segreta per l'accesso al servizio AWS Translate."
+
+#: ../chatgpt/controlpanel.py:38
+msgid "Model"
+msgstr "Modello"
+
+#: ../chatgpt/controlpanel.py:44
+msgid "Temperature"
+msgstr "Temperatura"
+
+#: ../chatgpt/controlpanel.py:44
+msgid "Controls randomness: 0 for deterministic, higher values for more random. Value between 0 and 2."
+msgstr "Controlla la casualità: 0 per deterministico, valori più alti per più casualità. Valore tra 0 e 2."
+
+#: ../chatgpt/controlpanel.py:52
+msgid "Max Tokens"
+msgstr "Token Massimi"
+
+#: ../chatgpt/controlpanel.py:52
+msgid "Maximum number of tokens to generate in the translation response."
+msgstr "Numero massimo di token da generare nella risposta di traduzione."a chiave segreta per l'accesso al servizio AWS Translate."
 
 #: ../libretranslate/controlpanel.py:19
 msgid "URL of the Libre Translate instance"

--- a/src/collective/translators/profiles/default/controlpanel.xml
+++ b/src/collective/translators/profiles/default/controlpanel.xml
@@ -59,4 +59,15 @@
     <permission>Manage portal</permission>
   </configlet>
 
+  <configlet action_id="chatgpt-translator-controlpanel"
+             appId="chatgpt-translator-controlpanel"
+             category="Products"
+             title="ChatGPT Settings"
+             url_expr="string:${portal_url}/@@chatgpt-translator-controlpanel"
+             visible="True"
+             i18n:attributes="title"
+  >
+    <permission>Manage portal</permission>
+  </configlet>
+
 </object>

--- a/src/collective/translators/profiles/default/registry/chatgpt.xml
+++ b/src/collective/translators/profiles/default/registry/chatgpt.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<registry xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+          i18n:domain="collective.translators"
+>
+  <!-- ChatGPT Control Panel -->
+  <records interface="collective.translators.chatgpt.controlpanel.IChatGPTControlPanel">
+    <value key="enabled">False</value>
+    <value key="order">30</value>
+    <value key="source_languages" />
+    <value key="target_languages" />
+    <value key="api_key">YOUR_OPENAI_API_KEY</value>
+    <value key="base_url"></value>
+    <value key="model">gpt-3.5-turbo</value>
+    <value key="temperature">0.3</value>
+    <value key="max_tokens">1000</value>
+  </records>
+</registry>

--- a/src/collective/translators/profiles/default/registry/chatgpt.xml
+++ b/src/collective/translators/profiles/default/registry/chatgpt.xml
@@ -9,7 +9,7 @@
     <value key="source_languages" />
     <value key="target_languages" />
     <value key="api_key">YOUR_OPENAI_API_KEY</value>
-    <value key="base_url"></value>
+    <value key="base_url" />
     <value key="model">gpt-3.5-turbo</value>
     <value key="temperature">0.3</value>
     <value key="max_tokens">1000</value>


### PR DESCRIPTION
Added another utility that perform the automatic translation implementing the `"plone.app.multilingual.interfaces.IExternalTranslationService" `interface. The general shape and logic is the same as the other services already implemented.

Added a new controlpanel where it is possible to define the API key and other configuration for the service that is called; the documentation used for reference is [https://developers.openai.com/api/reference/overview](https://developers.openai.com/api/reference/overview).

**Important note**: the python package `openai` is required (a `zcml:condition` is used to ensure that).

**Other note**: in this pr there is also a fix for a LibreTranslate issue in the file `src/collective/translators/libretranslate/utility.py`. It'not appropriate to have it here, maybe in the future it will be put in ins own pr.
